### PR TITLE
Fixed retry bug in "put" function

### DIFF
--- a/amazonclouddrivebackend.py
+++ b/amazonclouddrivebackend.py
@@ -71,7 +71,12 @@ class ACDBackend(duplicity.backend.Backend):
         deleteFile = False
         if(source_path.name != local_real_duplicity_file):
             try:
-                os.link(source_path.name, local_real_duplicity_file)
+                if os.path.exists(local_real_duplicity_file):
+                    try:
+                        os.remove(local_real_duplicity_file)
+                    except OSError, e:
+                        log.FatalError("Unable to remove file %s" % e)                    
+                os.symlink(source_path.name, local_real_duplicity_file)
                 deleteFile = True
             except IOError, e:
                 log.FatalError("Unable to copy " + source_path.name + " to " + local_real_duplicity_file)
@@ -85,7 +90,6 @@ class ACDBackend(duplicity.backend.Backend):
                 os.remove(local_real_duplicity_file)
             except OSError, e:
                 log.FatalError("Unable to remove file %s" % e)
-
 
     def _get(self, remote_filename, local_path):
         """Get remote filename, saving it to local_path"""

--- a/amazonclouddrivebackend.py
+++ b/amazonclouddrivebackend.py
@@ -71,11 +71,6 @@ class ACDBackend(duplicity.backend.Backend):
         deleteFile = False
         if(source_path.name != local_real_duplicity_file):
             try:
-                if os.path.exists(local_real_duplicity_file):
-                    try:
-                        os.remove(local_real_duplicity_file)
-                    except OSError, e:
-                        log.FatalError("Unable to remove file %s" % e)                    
                 os.symlink(source_path.name, local_real_duplicity_file)
                 deleteFile = True
             except IOError, e:
@@ -83,13 +78,15 @@ class ACDBackend(duplicity.backend.Backend):
 
         commandline = self.acd_cmd + " upload --force --overwrite '%s' '%s'" % \
             (local_real_duplicity_file, remote_path)
-        l = self.subprocess_popen(commandline)
 
-        if (deleteFile):
-            try:
-                os.remove(local_real_duplicity_file)
-            except OSError, e:
-                log.FatalError("Unable to remove file %s" % e)
+        try:
+            l = self.subprocess_popen(commandline)
+        finally:
+            if (deleteFile):
+                try:
+                    os.remove(local_real_duplicity_file)
+                except OSError, e:
+                    log.FatalError("Unable to remove file %s" % e)
 
     def _get(self, remote_filename, local_path):
         """Get remote filename, saving it to local_path"""


### PR DESCRIPTION
Sometimes, the put function can fail for various reasons (for example a read timeout that I was getting: `Uploading "duplicity-full.20151230T162510Z.vol27.difftar.gpg" failed. RequestError: 1000, HTTPSConnectionPool(host='content-na.drive.amazonaws.com', port=443): Read timed out`)

When this occurs, it seems the function does not properly clean up after itself by deleting the linked file, which causes subsequent attempts to fail instantly as `os.link` throws when the target file already exists: 

```
Attempt 2 failed. OSError: [Errno 17] File exists
Attempt 3 failed. OSError: [Errno 17] File exists
Attempt 4 failed. OSError: [Errno 17] File exists
Attempt 5 failed. OSError: [Errno 17] File exists
Attempt 6 failed. OSError: [Errno 17] File exists
Attempt 7 failed. OSError: [Errno 17] File exists
Attempt 8 failed. OSError: [Errno 17] File exists
Attempt 9 failed. OSError: [Errno 17] File exists
Attempt 10 failed. OSError: [Errno 17] File exists
Attempt 11 failed. OSError: [Errno 17] File exists
Attempt 12 failed. OSError: [Errno 17] File exists
Attempt 13 failed. OSError: [Errno 17] File exists
Attempt 14 failed. OSError: [Errno 17] File exists
Attempt 15 failed. OSError: [Errno 17] File exists
Attempt 16 failed. OSError: [Errno 17] File exists
Attempt 17 failed. OSError: [Errno 17] File exists
Attempt 18 failed. OSError: [Errno 17] File exists
Attempt 19 failed. OSError: [Errno 17] File exists
Giving up after 20 attempts. OSError: [Errno 17] File exists
```

This patch corrects the issue by checking for the existence of the target file before taking any action and removing it if it exists or reporting an error if it can't be removed. We also switch from using `os.link` to `os.symlink` as symbolic links are a little more flexible than hard links and there is no reason to prefer hard links in this case.
